### PR TITLE
Adds size validation in Mac Address and changes a test oid

### DIFF
--- a/example/bulk_walk_snmp.go
+++ b/example/bulk_walk_snmp.go
@@ -64,7 +64,7 @@ func (b *BulkWalkSnmp) BulkWalk(target string, oid string, community string) {
 		case gosnmp.OctetString:
 			mac := util.ValidateMAC(pdu.Value.([]byte))
 			if mac != "" {
-				buffer.WriteString(fmt.Sprintf("host=%s oid=%s value=%s\n", target, pdu.Name, mac))
+				buffer.WriteString(fmt.Sprintf("host=%s oid=%s mac=%s\n", target, pdu.Name, mac))
 				break
 			}
 			buffer.WriteString(fmt.Sprintf("host=%s oid=%s string=%s\n", target, pdu.Name, string(pdu.Value.([]byte))))
@@ -84,8 +84,8 @@ func (b *BulkWalkSnmp) BulkWalk(target string, oid string, community string) {
 //Run prepares the sample data and sets the Goroutine parameters.
 //TODO: Receive sample configuration parameters.
 func (b *BulkWalkSnmp) Run() {
-	host := "10.29.63.10"
-	oid := ".1.3.6.1.2.1"
+	host := "10.29.63.30"
+	oid := ".1.3.6.1.2.1.25.3.5.1"
 	community := "public"
 
 	b.BulkWalk(host, oid, community)

--- a/util/util.go
+++ b/util/util.go
@@ -22,17 +22,28 @@
 
 package util
 
-import "net"
+import (
+	"fmt"
+	"net"
+)
 
 // ValidateMAC checks if the []byte passed is a Mac Address and if so, checks to see if it is valid.
 // ParseMAC parses s as an IEEE 802 MAC-48, EUI-48, EUI-64, or a 20-octet
 func ValidateMAC(bytes []byte) string {
 	var hw net.HardwareAddr
 	hw = bytes
+	if len(hw.String()) != 17 {
+		return ""
+	}
 	hw, err := net.ParseMAC(hw.String())
 	if err != nil {
 		return ""
 	}
 
 	return hw.String()
+}
+
+//FormatLog returns the message in the pattern that the developer wants.
+func FormatLog(host string, oid string, message string) string {
+	return fmt.Sprintf("host=%s oid=%s %s", host, oid, message)
 }


### PR DESCRIPTION
Adds a Mac Address size validation of 17. This excludes the possibility of Go's native ParserMAC to identify Mac of type EUI-64 and 20-octet. But it still identifies the EUI-48 standard that is not the Mac Address of network devices.
It changes oids to test, this change was random to try to identify other types of data provided by SNMP.